### PR TITLE
docs(KIWI): helm upgrade --install

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ You can deploy KIWI by using the general purpose [`refarch-templates` Helm Chart
 helm repo add it-at-m https://it-at-m.github.io/helm-charts
 
 # Install the Chart
-helm install my-kiwi-release it-at-m/refarch-templates --values values.yaml
+helm upgrade --install my-kiwi-release it-at-m/refarch-templates --values values.yaml
 ```
 
 A minimal `values.yaml` could be:


### PR DESCRIPTION
**Description**

helm upgrade --install is better for updates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Helm command syntax documented in the README. The installation guide now references using `helm upgrade --install` instead of `helm install` for deploying releases. Users preparing their deployments should refer to and follow the updated command pattern in the README documentation when setting up their release environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->