### PR TITLE
fix(KIWI): adjust baseBranches in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
 
-  "baseBranches": ["next", "/^release\\/.*/"],
+  "baseBranches": ["dev"],
 
   "timezone": "Europe/Berlin",
   "schedule": ["on saturday between 4am and 6am"]


### PR DESCRIPTION
**Description**

Renovate was configured with non-existing and invalid base branches (`next` and a regex for `release/*`). This caused Renovate to stop creating PRs as a safety precaution.

This change:

- Removes the invalid `baseBranches` entries
- Configures Renovate to use `dev` as the only base branch

Renovate should resume creating dependency update PRs after this change.

**Reference**

Issues #204
